### PR TITLE
Adding setRtcEngine prop on AgoraUIKit component

### DIFF
--- a/src/PropsContext.tsx
+++ b/src/PropsContext.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {StyleProp, ViewStyle} from 'react-native';
-import {StreamFallbackOptions, VideoRenderMode} from 'react-native-agora';
+import RtcEngine, {StreamFallbackOptions, VideoRenderMode} from 'react-native-agora';
 import {RtcEngineEvents} from 'react-native-agora/src/common/RtcEvents';
 
 /**
@@ -284,6 +284,10 @@ export interface PropsInterface {
    * Callbacks for different functions of the UI Kit
    */
   callbacks?: Partial<CallbacksInterface>;
+  /**
+   * Function to expose the current RtcEngine instance (for example, to allow setting new event listeners)
+   */
+  setRtcEngine(engine: RtcEngine): void;
 }
 
 /**

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -256,7 +256,7 @@ const RtcConfigure: React.FC<Partial<RtcPropsInterface>> = (props) => {
       try {
         engine.current = await RtcEngine.create(rtcProps.appId);
         console.log(engine.current);
-        setRtcEngine(engine.current);
+        setRtcEngine && setRtcEngine(engine.current);
         await engine.current.enableVideo();
 
         /* Listeners */

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -33,7 +33,7 @@ import {MaxUidProvider} from './MaxUidContext';
  * It's a collection of providers to wrap your components that need access to user data or engine dispatch
  */
 const RtcConfigure: React.FC<Partial<RtcPropsInterface>> = (props) => {
-  const {callbacks, rtcProps} = useContext(PropsContext);
+  const {callbacks, rtcProps, setRtcEngine} = useContext(PropsContext);
   const [ready, setReady] = useState<boolean>(false);
   let joinRes: ((arg0: boolean) => void) | null = null;
   let canJoin = useRef(new Promise<boolean | void>((res) => (joinRes = res)));
@@ -256,6 +256,7 @@ const RtcConfigure: React.FC<Partial<RtcPropsInterface>> = (props) => {
       try {
         engine.current = await RtcEngine.create(rtcProps.appId);
         console.log(engine.current);
+        setRtcEngine(engine.current);
         await engine.current.enableVideo();
 
         /* Listeners */


### PR DESCRIPTION
The new setRtcEngine prop will allow to expose the RtcEngine instance while using the AgoraUIKit component.

Exposing the RtcEngine instance will allow the creation of new event listener and other configurations.