### PR TITLE
Updated condition creating the geo fencing object

### DIFF
--- a/src/Contexts/PropsContext.tsx
+++ b/src/Contexts/PropsContext.tsx
@@ -72,6 +72,7 @@ export interface RtcPropsInterface {
       | EncryptionMode.AES256XTS
       | EncryptionMode.AES128ECB;
   };
+  geoFencing?: boolean
 }
 
 export interface CallbacksInterface {

--- a/src/Rtc/Create.tsx
+++ b/src/Rtc/Create.tsx
@@ -27,7 +27,7 @@ const Create = ({
         await requestCameraAndAudioPermission();
       }
       try {
-        if (Platform.OS === 'android' || Platform.OS === 'ios') {
+        if (rtcProps.geoFencing === true && (Platform.OS === 'android' || Platform.OS === 'ios')) {
           engine.current = await RtcEngine.createWithAreaCode(
             rtcProps.appId,
             // eslint-disable-next-line no-bitwise


### PR DESCRIPTION
Related Issue
- Hidden magic variable for geo-fencing
- Clickup ticket - https://app.clickup.com/t/1tjwczh


Proposed Changes/fix
- Need to pass the geofencing flag as rtc props input and update the condition to create geo fencing functionality
- Updated the props context and condition to create - RtcEngine.createWithAreaCode