### PR TITLE
BUGFIX - Hangup icons/text on participants and end call is not consistence

### DIFF
--- a/src/Controls/BtnTemplate.tsx
+++ b/src/Controls/BtnTemplate.tsx
@@ -51,10 +51,7 @@ const BtnTemplate: React.FC<BtnTemplateInterface> = (props) => {
             width: '100%',
             height: '100%',
             opacity: disabled ?  0.4 : 1,
-            tintColor: disabled ? 'grey' :
-              (props.name !== 'callEnd' && props.name !== 'recordingActiveIcon'
-                ? theme || props.color || '#fff'
-                : '#FD0845'),
+            tintColor: disabled ? 'grey' : ( props.color || theme || '#fff')
           }}
           resizeMode={'contain'}
           source={{uri: icons[props.name]}}
@@ -64,7 +61,7 @@ const BtnTemplate: React.FC<BtnTemplateInterface> = (props) => {
         style={{
           textAlign: 'center',
           marginTop: 5,
-          color: disabled ? 'grey' : (theme || props.color || '#fff'),
+          color: disabled ? 'grey' : (props.color || theme || '#fff'),
           opacity: disabled ? 0.4 : 1
         }}>
         {props.btnText}

--- a/src/Controls/ImageIcon.tsx
+++ b/src/Controls/ImageIcon.tsx
@@ -40,10 +40,7 @@ const ImageIcon: React.FC<ImageIconInterface> = (props) => {
         {
           width: '100%',
           height: '100%',
-          tintColor:
-            props.name !== 'callEnd' && props.name !== 'recordingActiveIcon'
-              ? props.color || theme || '#fff'
-              : '#FD0845',
+          tintColor: props.color || theme || '#fff'              
         },
         props.style as object,
       ]}

--- a/src/Controls/Local/EndCall.tsx
+++ b/src/Controls/Local/EndCall.tsx
@@ -14,6 +14,7 @@ function EndCall() {
     <BtnTemplate
       name={'callEnd'}
       btnText={'Hang Up'}
+      color='#FD0845'
       style={{...styles.endCall, ...(endCall as object)}}
       onPress={() =>
         dispatch({


### PR DESCRIPTION
Issue:
Hangup icons/text on participants and end call is not consistence
https://app.clickup.com/t/1ykzh2b
Changes:
To fix the color : Instead comparing the icon name passed the color value from the end call on video call screen/participants panel
Updated color for copy meeting invite button