### PR TITLE
Added default video and audio modes for RTC

### DIFF
--- a/src/Contexts/PropsContext.tsx
+++ b/src/Contexts/PropsContext.tsx
@@ -255,6 +255,14 @@ export interface RtcSettings {
    * Disable Agora RTM, this also disables the use of usernames and remote mute functionality
    */
   disableRtm?: boolean;
+  /**
+   * Enable / Disable audio when user first joins the channel
+   */
+  defaultAudio?:boolean;
+  /**
+   * Enable / Disable video when user first joins the channel
+   */
+  defaultVideo?:boolean;
   // /**
   //  * Enable the mic before joining the call. (default: true)
   //  */

--- a/src/Rtc/Join.tsx
+++ b/src/Rtc/Join.tsx
@@ -28,7 +28,27 @@ const Join: React.FC<
       }
     }
     const videoState = uidState.max[0].video;
+
+    function setDefaults() {
+      // explictly checking for false as anything else will be treated as default case with video enabled.
+      if(rtcProps.defaultVideo === false){
+        engine.muteLocalVideoStream(true)
+        dispatch({
+          type: 'LocalMuteVideo',
+          value: [ToggleState.disabled],
+        });
+      }
+      if(rtcProps.defaultAudio === false){
+        engine.muteLocalAudioStream(true)
+        dispatch({
+          type: 'LocalMuteAudio',
+          value: [ToggleState.disabled],
+        });
+      }
+    }
+
     async function join() {
+
       if (
         rtcProps.encryption &&
         rtcProps.encryption.key &&
@@ -59,6 +79,7 @@ const Join: React.FC<
         )
           .then((response) => {
             response.json().then((data) => {
+              setDefaults()
               engine.joinChannel(data.rtcToken, rtcProps.channel, UID, {});
             });
           })
@@ -66,6 +87,7 @@ const Join: React.FC<
             console.log('Fetch Error', err);
           });
       } else {
+        setDefaults()
         await engine.joinChannel(
           rtcProps.token ? rtcProps.token : '',
           rtcProps.channel,


### PR DESCRIPTION
I've added default modes to enable and disable video and audio. This can be controlled by rtc settings props.
Usage :
```
<AgoraUIKit settings={{
            defaultVideo:false,
            defaultAudio:true
        }} connectionData={connectionData} rtcCallbacks={rtcCallbacks} />
```
This will enable audio while disabling video when the user first joins. they can then click on the control buttons and enable video if required